### PR TITLE
Fix missing temp dir in base transcription

### DIFF
--- a/base.py
+++ b/base.py
@@ -43,6 +43,9 @@ def on_key_press(key):
 def main():
     global recording, recording_data
 
+    # Ensure the temp directory exists before we try to write files
+    os.makedirs(TEMP_DIR, exist_ok=True)
+
     # Parse command line arguments
     language = "auto"
     for arg in sys.argv[1:]:


### PR DESCRIPTION
## Summary
- ensure temporary directory exists before writing audio in `base.py`

## Testing
- `python -m py_compile base.py live.py`

------
https://chatgpt.com/codex/tasks/task_e_687a7debd934832a9c498a27194da4f9