### PR TITLE
Fix help usage string

### DIFF
--- a/live.py
+++ b/live.py
@@ -400,7 +400,7 @@ def main():
         if arg.startswith("--lang="):
             language = arg.split("=", 1)[1]
         elif arg == "--help" or arg == "-h":
-            print("Usage: python local-transcription.py [OPTIONS]")
+            print("Usage: python live.py [OPTIONS]")
             print("Options:")
             print("  --lang=LANGUAGE       Set transcription language (default: auto)")
             print("  --help, -h           Show this help message")


### PR DESCRIPTION
## Summary
- corrected usage string in `live.py` help message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a80e66f08832ab90dde560e0c5606