### PR TITLE
Fix Whisper paths for macOS app

### DIFF
--- a/LemonWhisper/LemonWhisper/WhisperManager.swift
+++ b/LemonWhisper/LemonWhisper/WhisperManager.swift
@@ -24,26 +24,16 @@ class WhisperManager: ObservableObject {
     }
 
     private func initializeWhisper() async {
-        guard let whisperCppPath = ProcessInfo.processInfo.environment["WHISPER_CPP_PATH"] else {
-            self.alertMessage = "WHISPER_CPP_PATH environment variable is not set."
+        guard let modelURL = Bundle.main.url(forResource: "ggml-large-v3-turbo", withExtension: "bin"),
+              let vadURL = Bundle.main.url(forResource: "ggml-silero-v5.1.2", withExtension: "bin")
+        else {
+            self.alertMessage = "Model files not found in the application bundle."
             self.showAlert = true
             return
         }
 
-        let modelPath = "\(whisperCppPath)/models/ggml-large-v3-turbo.bin"
-        let vadModelPath = "\(whisperCppPath)/models/ggml-silero-v5.1.2.bin"
-
-        if !FileManager.default.fileExists(atPath: modelPath) {
-            self.alertMessage = "Model file not found at \(modelPath)"
-            self.showAlert = true
-            return
-        }
-
-        if !FileManager.default.fileExists(atPath: vadModelPath) {
-            self.alertMessage = "VAD model file not found at \(vadModelPath)"
-            self.showAlert = true
-            return
-        }
+        let modelPath = modelURL.path
+        let vadModelPath = vadURL.path
 
         do {
             self.whisperContext = try await WhisperContext.createContext(path: modelPath)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ This will:
 
 ✅ No additional edits needed.
 
+### macOS app setup
+
+To use the bundled macOS app, add the Whisper models to the Xcode project:
+
+1. Open `LemonWhisper.xcodeproj`.
+2. Drag `ggml-large-v3-turbo.bin` and `ggml-silero-v5.1.2.bin` from `whisper.cpp/models` into the **Resources** group. Ensure *Copy items if needed* is checked so the files are bundled with the app.
+3. Build and run the app normally.
+
 ## ⚙️ Configure Hammerspoon
 
 Hammerspoon handles the global hotkey and the 🍋 indicator.


### PR DESCRIPTION
## Summary
- load model and VAD files from the app bundle rather than `WHISPER_CPP_PATH`
- document Xcode setup for bundling the models

## Testing
- `python -m py_compile base.py live.py common.py logger_config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688398871550832aa01ba549dc9aa0b3