### PR TITLE
Fast/Lazy model-loading modes + recording timestamps

### DIFF
--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelMemory.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelMemory.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+extension LemonWhisperController {
+    /// The memory controller for whichever backend is currently selected.
+    var memoryController: ModelMemoryController {
+        switch selectedBackend {
+        case .whisper:
+            return WhisperMemoryController()
+        case .voxtral:
+            return VoxtralMemoryController()
+        }
+    }
+
+    func setModelLoadingMode(_ mode: ModelLoadingMode) {
+        guard mode != modelLoadingMode else { return }
+        modelLoadingMode = mode
+        AppSettingsStore.modelLoadingMode = mode
+        debugLog("⚙️ Model loading mode set to \(mode.rawValue)")
+
+        switch mode {
+        case .fast:
+            // Cancel any pending unload and load the model now, fully resident.
+            cancelIdleUnloadTimer()
+            warmUpCurrentBackendInBackground(weightMaterializationBudget: .infinity)
+        case .lazy:
+            // Start counting toward an idle unload from now.
+            scheduleIdleUnloadIfNeeded()
+        }
+    }
+
+    /// Loads the active backend's model off the main actor without blocking recording.
+    /// Idempotent: skips the work if the model is already resident. `weightMaterializationBudget`
+    /// is forwarded to the backend to decide whether to eagerly materialize weights now.
+    func warmUpCurrentBackendInBackground(weightMaterializationBudget: TimeInterval?) {
+        let controller = memoryController
+        Task.detached { [weak self] in
+            if await controller.isLoaded() { return }
+            do {
+                try await controller.warmUp(weightMaterializationBudget: weightMaterializationBudget)
+            } catch {
+                await MainActor.run {
+                    debugLog("⚠️ Background warmup failed: \(error.localizedDescription)")
+                }
+            }
+            await MainActor.run { self?.refreshRuntimeStatusSoon() }
+        }
+    }
+
+    func setModelIdleTimeout(_ timeout: ModelIdleTimeout) {
+        guard timeout != modelIdleTimeout else { return }
+        modelIdleTimeout = timeout
+        AppSettingsStore.modelIdleTimeout = timeout
+        debugLog("⚙️ Model idle timeout set to \(timeout.rawValue)")
+        // Re-arm the countdown with the new value when idle in lazy mode.
+        if !isRecording {
+            scheduleIdleUnloadIfNeeded()
+        }
+    }
+
+    /// Restarts the idle-unload countdown. No-op unless lazy mode is active.
+    func scheduleIdleUnloadIfNeeded() {
+        cancelIdleUnloadTimer()
+        guard modelLoadingMode == .lazy else { return }
+
+        idleUnloadTimer = Timer.scheduledTimer(withTimeInterval: modelIdleTimeout.seconds, repeats: false) { [weak self] _ in
+            Task { @MainActor in
+                self?.unloadCurrentBackendForIdle()
+            }
+        }
+    }
+
+    func cancelIdleUnloadTimer() {
+        idleUnloadTimer?.invalidate()
+        idleUnloadTimer = nil
+    }
+
+    private func unloadCurrentBackendForIdle() {
+        guard modelLoadingMode == .lazy, !isRecording else { return }
+        let controller = memoryController
+        let backend = selectedBackend
+        debugLog("💤 Idle timeout reached — unloading \(backend.rawValue) model")
+        Task.detached { [weak self] in
+            await controller.unload()
+            await MainActor.run { self?.refreshRuntimeStatusSoon() }
+        }
+    }
+}

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelMemory.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelMemory.swift
@@ -33,7 +33,7 @@ extension LemonWhisperController {
     /// is forwarded to the backend to decide whether to eagerly materialize weights now.
     func warmUpCurrentBackendInBackground(weightMaterializationBudget: TimeInterval?) {
         let controller = memoryController
-        Task.detached { [weak self] in
+        Task.detached {
             if await controller.isLoaded() { return }
             do {
                 try await controller.warmUp(weightMaterializationBudget: weightMaterializationBudget)
@@ -42,7 +42,6 @@ extension LemonWhisperController {
                     debugLog("⚠️ Background warmup failed: \(error.localizedDescription)")
                 }
             }
-            await MainActor.run { self?.refreshRuntimeStatusSoon() }
         }
     }
 
@@ -79,9 +78,8 @@ extension LemonWhisperController {
         let controller = memoryController
         let backend = selectedBackend
         debugLog("💤 Idle timeout reached — unloading \(backend.rawValue) model")
-        Task.detached { [weak self] in
+        Task.detached {
             await controller.unload()
-            await MainActor.run { self?.refreshRuntimeStatusSoon() }
         }
     }
 }

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelSetup.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelSetup.swift
@@ -20,9 +20,8 @@ extension LemonWhisperController {
         case .whisper:
             selectedBackend = .whisper
             UserDefaults.standard.set(TranscriptionBackend.whisper.rawValue, forKey: selectedBackendDefaultsKey)
-            Task { @MainActor in
+            Task {
                 await VoxtralService.shared.unload()
-                refreshRuntimeStatusSoon()
             }
             ensureWhisperReady()
         case .voxtral:
@@ -385,7 +384,6 @@ extension LemonWhisperController {
                 }
                 whisperStatus = "Whisper ready: \(selected.title)"
                 setupState = .ready
-                refreshRuntimeStatusSoon()
                 debugLog("✅ Whisper ready: \(selected.id)")
             } catch {
                 let message = "Failed to load Whisper: \(error.localizedDescription)"
@@ -445,7 +443,6 @@ extension LemonWhisperController {
             selectedBackend = .voxtral
             UserDefaults.standard.set(TranscriptionBackend.voxtral.rawValue, forKey: selectedBackendDefaultsKey)
             setupState = .ready
-            refreshRuntimeStatusSoon()
             debugLog("✅ Voxtral ready. Switched backend")
             return true
         } catch {

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelSetup.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelSetup.swift
@@ -20,8 +20,9 @@ extension LemonWhisperController {
         case .whisper:
             selectedBackend = .whisper
             UserDefaults.standard.set(TranscriptionBackend.whisper.rawValue, forKey: selectedBackendDefaultsKey)
-            Task {
+            Task { @MainActor in
                 await VoxtralService.shared.unload()
+                refreshRuntimeStatusSoon()
             }
             ensureWhisperReady()
         case .voxtral:
@@ -357,18 +358,26 @@ extension LemonWhisperController {
     }
 
     private func ensureWhisperReady() {
+        guard let selected = WhisperModelCatalog.selectedModelIfDownloaded() else {
+            let message = "Download a Whisper model to use Whisper."
+            whisperStatus = message
+            setupState = .blocked(message: message)
+            return
+        }
+
+        if modelLoadingMode == .lazy {
+            // Optimistic: the model exists on disk. It loads on demand (or in parallel with recording).
+            whisperStatus = "Whisper ready: \(selected.title)"
+            setupState = .ready
+            debugLog("🐢 Whisper ready (lazy): \(selected.id)")
+            return
+        }
+
         setupState = .preparingSelectedModel
         debugLog("🧠 Preparing Whisper model")
 
         Task { @MainActor in
             do {
-                guard let selected = WhisperModelCatalog.selectedModelIfDownloaded() else {
-                    let message = "Download a Whisper model to use Whisper."
-                    whisperStatus = message
-                    setupState = .blocked(message: message)
-                    return
-                }
-
                 _ = try await WhisperContext.createContext(path: selected.localURL.path)
                 try await WhisperModelCatalog.ensureVADDownloadedIfNeeded()
                 if let context = WhisperContext.getShared() {
@@ -376,6 +385,7 @@ extension LemonWhisperController {
                 }
                 whisperStatus = "Whisper ready: \(selected.title)"
                 setupState = .ready
+                refreshRuntimeStatusSoon()
                 debugLog("✅ Whisper ready: \(selected.id)")
             } catch {
                 let message = "Failed to load Whisper: \(error.localizedDescription)"
@@ -406,7 +416,18 @@ extension LemonWhisperController {
             return false
         }
 
-        if await VoxtralService.shared.isReady {
+        let voxtralAlreadyReady = await VoxtralService.shared.isReady
+
+        if modelLoadingMode == .lazy && !voxtralAlreadyReady {
+            // Optimistic: the model exists on disk. It loads on demand (or in parallel with recording).
+            selectedBackend = .voxtral
+            UserDefaults.standard.set(TranscriptionBackend.voxtral.rawValue, forKey: selectedBackendDefaultsKey)
+            setupState = .ready
+            debugLog("🐢 Voxtral ready (lazy): \(selectedVoxtralModelID)")
+            return true
+        }
+
+        if voxtralAlreadyReady {
             selectedBackend = .voxtral
             UserDefaults.standard.set(TranscriptionBackend.voxtral.rawValue, forKey: selectedBackendDefaultsKey)
             setupState = .ready
@@ -420,10 +441,11 @@ extension LemonWhisperController {
         defer { isPreparingVoxtral = false }
 
         do {
-            try await VoxtralService.shared.warmupModel()
+            try await VoxtralService.shared.warmupModel(weightMaterializationBudget: .infinity)
             selectedBackend = .voxtral
             UserDefaults.standard.set(TranscriptionBackend.voxtral.rawValue, forKey: selectedBackendDefaultsKey)
             setupState = .ready
+            refreshRuntimeStatusSoon()
             debugLog("✅ Voxtral ready. Switched backend")
             return true
         } catch {

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelSetup.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+ModelSetup.swift
@@ -242,6 +242,18 @@ extension LemonWhisperController {
         !downloadedWhisperModels.isEmpty || (supportsVoxtral && !downloadedVoxtralModels.isEmpty)
     }
 
+    /// Whether the selected backend's model is downloaded and on disk. Recording requires this,
+    /// so we never start capturing while a model is still downloading or during bootstrapping —
+    /// only while an already-downloaded model is loading into memory.
+    var hasUsableSelectedModel: Bool {
+        switch selectedBackend {
+        case .whisper:
+            return isWhisperModelDownloaded(selectedWhisperModelID)
+        case .voxtral:
+            return isVoxtralModelDownloaded(selectedVoxtralModelID)
+        }
+    }
+
     var showsSetupCard: Bool {
         setupState.isBlocking
     }

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+Recording.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+Recording.swift
@@ -49,6 +49,9 @@ extension LemonWhisperController {
         RecordingPulseHUD.shared.showPulse(isRecording: false)
         isRecording = false
         recordingStartedAt = nil
+        // No transcription will fire to re-arm it, so restart the idle countdown here —
+        // otherwise a model loaded by this recording's parallel warmup never unloads.
+        scheduleIdleUnloadIfNeeded()
     }
 
     var canStartNewRecording: Bool {

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+Recording.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+Recording.swift
@@ -6,10 +6,11 @@ extension LemonWhisperController {
         debugLog("🎙️ toggleRecording invoked. isRecording=\(isRecording) canStartNewRecording=\(canStartNewRecording)")
 
         if isRecording {
+            let stoppedAt = Date()
             debugLog("🛑 Stopping recording")
             recorder.stopRecording()
             RecordingPulseHUD.shared.showPulse(isRecording: false)
-            transcribeLatestRecording()
+            transcribeLatestRecording(recordingStoppedAt: stoppedAt)
             isRecording = false
             return
         }
@@ -19,7 +20,25 @@ extension LemonWhisperController {
             return
         }
 
+        recordingStartedAt = Date()
         startRecordingIfAuthorized()
+    }
+
+    /// Fallback recording length used to budget eager materialization before we've measured a
+    /// real recording (e.g. the first lazy-mode recording after launch).
+    static let assumedTypicalRecordingDuration: TimeInterval = 3
+
+    /// Called the moment recording begins. Keeps the model out of an idle unload and, in lazy
+    /// mode, starts loading it in parallel so it is ready by the time recording stops.
+    private func onRecordingDidStart() {
+        cancelIdleUnloadTimer()
+        if modelLoadingMode == .lazy {
+            // Load the pipeline in parallel with recording. The backend materializes weights now
+            // only if a prior measurement shows that pass fits within a typical recording;
+            // otherwise it defers to the transcription so it can never block it.
+            let budget = lastRecordingDuration ?? Self.assumedTypicalRecordingDuration
+            warmUpCurrentBackendInBackground(weightMaterializationBudget: budget)
+        }
     }
 
     func cancelRecording() {
@@ -29,13 +48,11 @@ extension LemonWhisperController {
         recorder.cancelRecording()
         RecordingPulseHUD.shared.showPulse(isRecording: false)
         isRecording = false
+        recordingStartedAt = nil
     }
 
     var canStartNewRecording: Bool {
-        if case .ready = setupState {
-            return true
-        }
-        return false
+        !setupState.blocksRecording
     }
 
     var recordingButtonTitle: String {
@@ -58,6 +75,7 @@ extension LemonWhisperController {
             }
             RecordingPulseHUD.shared.showPulse(isRecording: true)
             isRecording = true
+            onRecordingDidStart()
             debugLog("✅ Recording started")
         case .notDetermined:
             permissionManager.requestMicrophoneAccess { [weak self] granted in
@@ -72,6 +90,7 @@ extension LemonWhisperController {
                         }
                         RecordingPulseHUD.shared.showPulse(isRecording: true)
                         self.isRecording = true
+                        self.onRecordingDidStart()
                         debugLog("✅ Recording started after microphone permission prompt")
                     } else {
                         debugLog("❌ Microphone permission denied")
@@ -85,10 +104,17 @@ extension LemonWhisperController {
         }
     }
 
-    private func transcribeLatestRecording() {
+    private func transcribeLatestRecording(recordingStoppedAt: Date) {
         guard let wavURL = recorder.latestWavURL else {
             debugLog("⚠️ No latest recording URL available for transcription")
             return
+        }
+
+        let startedAt = recordingStartedAt
+        recordingStartedAt = nil
+
+        if let startedAt {
+            lastRecordingDuration = recordingStoppedAt.timeIntervalSince(startedAt)
         }
 
         debugLog("📝 Starting transcription. backend=\(selectedBackend.rawValue) file=\(wavURL.lastPathComponent)")
@@ -97,12 +123,16 @@ extension LemonWhisperController {
             language: selectedLanguageCode,
             backend: selectedBackend,
             targetBundleIdentifier: targetBundleIdentifier,
-            targetProcessID: targetProcessID
-        ) { isActive in
+            targetProcessID: targetProcessID,
+            recordingStartedAt: startedAt,
+            recordingStoppedAt: recordingStoppedAt
+        ) { [weak self] isActive in
             if isActive {
                 TranscriptionLoadingHUD.shared.show()
+                self?.cancelIdleUnloadTimer()
             } else {
                 TranscriptionLoadingHUD.shared.hide()
+                self?.scheduleIdleUnloadIfNeeded()
             }
         }
     }

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+Recording.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+Recording.swift
@@ -55,7 +55,9 @@ extension LemonWhisperController {
     }
 
     var canStartNewRecording: Bool {
-        !setupState.blocksRecording
+        // Optimistic once a model is on disk (it may still be loading), but never while there is
+        // no usable model — downloading, bootstrapping, or a failed/blocked setup.
+        hasUsableSelectedModel && !setupState.blocksRecording
     }
 
     var recordingButtonTitle: String {

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+System.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+System.swift
@@ -11,17 +11,6 @@ extension LemonWhisperController {
         processMemoryMB = currentProcessMemoryMB()
     }
 
-    /// Refreshes the memory readout now and once more shortly after, so mode changes and
-    /// idle unloads are reflected immediately instead of waiting for the next poll tick.
-    /// The follow-up catches memory that the allocator releases a beat after `unload()` returns.
-    func refreshRuntimeStatusSoon() {
-        refreshRuntimeStatus()
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 750_000_000)
-            refreshRuntimeStatus()
-        }
-    }
-
     func setupHotKeys() {
         HotKeyManager.registerToggleRecordingHotKey(
             into: &toggleHotKeyRef,

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+System.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+System.swift
@@ -11,6 +11,17 @@ extension LemonWhisperController {
         processMemoryMB = currentProcessMemoryMB()
     }
 
+    /// Refreshes the memory readout now and once more shortly after, so mode changes and
+    /// idle unloads are reflected immediately instead of waiting for the next poll tick.
+    /// The follow-up catches memory that the allocator releases a beat after `unload()` returns.
+    func refreshRuntimeStatusSoon() {
+        refreshRuntimeStatus()
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 750_000_000)
+            refreshRuntimeStatus()
+        }
+    }
+
     func setupHotKeys() {
         HotKeyManager.registerToggleRecordingHotKey(
             into: &toggleHotKeyRef,

--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController.swift
@@ -23,6 +23,8 @@ final class LemonWhisperController: ObservableObject {
     @Published var selectedMicrophoneID: String? = AppSettingsStore.selectedMicrophoneUniqueID
     @Published var availableMicrophones: [MicrophoneDevice] = MicrophoneManager.availableDevices()
     @Published var recordingShortcut: RecordingShortcut = AppSettingsStore.recordingShortcut
+    @Published var modelLoadingMode: ModelLoadingMode = AppSettingsStore.modelLoadingMode
+    @Published var modelIdleTimeout: ModelIdleTimeout = AppSettingsStore.modelIdleTimeout
 
     var whisperOperationsInFlight: Set<String> = []
     var voxtralOperationsInFlight: Set<String> = []
@@ -30,6 +32,9 @@ final class LemonWhisperController: ObservableObject {
     let recorder = AudioRecorder()
     var targetBundleIdentifier: String?
     var targetProcessID: pid_t?
+    var recordingStartedAt: Date?
+    var lastRecordingDuration: TimeInterval?
+    var idleUnloadTimer: Timer?
     var toggleHotKeyRef: EventHotKeyRef?
 
     let selectedBackendDefaultsKey = "selectedTranscriptionBackend"

--- a/LemonWhisper/LemonWhisper/Managers/TranscriptionManager.swift
+++ b/LemonWhisper/LemonWhisper/Managers/TranscriptionManager.swift
@@ -77,6 +77,8 @@ class TranscriptionManager {
         backend: TranscriptionBackend,
         targetBundleIdentifier: String?,
         targetProcessID: pid_t?,
+        recordingStartedAt: Date? = nil,
+        recordingStoppedAt: Date? = nil,
         onActivityChanged: ((Bool) -> Void)? = nil
     ) {
         Task {
@@ -127,7 +129,9 @@ class TranscriptionManager {
                         rawText: sanitized,
                         language: language,
                         backend: backend,
-                        targetBundleIdentifier: targetBundleIdentifier
+                        targetBundleIdentifier: targetBundleIdentifier,
+                        recordingStartedAt: recordingStartedAt,
+                        recordingStoppedAt: recordingStoppedAt
                     )
                 } else {
                     savedRecord = nil

--- a/LemonWhisper/LemonWhisper/Models/ModelIdleTimeout.swift
+++ b/LemonWhisper/LemonWhisper/Models/ModelIdleTimeout.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// How long the model stays resident with no activity before lazy mode unloads it.
+enum ModelIdleTimeout: String, CaseIterable, Identifiable {
+    case thirtySeconds
+    case oneMinute
+    case twoMinutes
+    case fiveMinutes
+
+    var id: String { rawValue }
+
+    /// Seconds of inactivity before the model is unloaded.
+    var seconds: TimeInterval {
+        switch self {
+        case .thirtySeconds: return 30
+        case .oneMinute: return 60
+        case .twoMinutes: return 120
+        case .fiveMinutes: return 300
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .thirtySeconds: return "30 seconds"
+        case .oneMinute: return "1 minute"
+        case .twoMinutes: return "2 minutes"
+        case .fiveMinutes: return "5 minutes"
+        }
+    }
+}

--- a/LemonWhisper/LemonWhisper/Models/ModelLoadingMode.swift
+++ b/LemonWhisper/LemonWhisper/Models/ModelLoadingMode.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Controls how aggressively the selected transcription model is kept in memory.
+enum ModelLoadingMode: String, CaseIterable, Identifiable {
+    /// Load the model at startup and keep it resident. Fastest transcriptions, highest memory use.
+    case fast
+    /// Skip startup loading and free the model after a period of inactivity. Lower memory, slower first transcription.
+    case lazy
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .fast:
+            return "Fast (keep model in memory)"
+        case .lazy:
+            return "Lazy (free memory when idle)"
+        }
+    }
+
+    var menuTitle: String {
+        switch self {
+        case .fast:
+            return "Fast"
+        case .lazy:
+            return "Lazy"
+        }
+    }
+}

--- a/LemonWhisper/LemonWhisper/Models/SetupState.swift
+++ b/LemonWhisper/LemonWhisper/Models/SetupState.swift
@@ -14,6 +14,17 @@ enum SetupState: Equatable {
         }
     }
 
+    /// Recording is refused only when no usable model exists on disk. If a model is
+    /// available we start optimistically, even while it is still loading into memory.
+    var blocksRecording: Bool {
+        switch self {
+        case .awaitingModelSelection, .blocked:
+            return true
+        case .bootstrapping, .ready, .preparingSelectedModel:
+            return false
+        }
+    }
+
     var cardTitle: String? {
         switch self {
         case .bootstrapping, .ready:

--- a/LemonWhisper/LemonWhisper/Services/AppSettingsStore.swift
+++ b/LemonWhisper/LemonWhisper/Services/AppSettingsStore.swift
@@ -5,6 +5,32 @@ enum AppSettingsStore {
     static var defaults = UserDefaults.standard
     private static let recordingShortcutKey = "recordingShortcut"
     private static let selectedMicrophoneUniqueIDKey = "selectedMicrophoneUniqueID"
+    private static let modelLoadingModeKey = "modelLoadingMode"
+    private static let modelIdleTimeoutKey = "modelIdleTimeout"
+
+    /// How the transcription model is kept in memory. Defaults to `.fast` to preserve prior behavior.
+    static var modelLoadingMode: ModelLoadingMode {
+        get {
+            guard let raw = defaults.string(forKey: modelLoadingModeKey),
+                  let mode = ModelLoadingMode(rawValue: raw) else {
+                return .fast
+            }
+            return mode
+        }
+        set { defaults.set(newValue.rawValue, forKey: modelLoadingModeKey) }
+    }
+
+    /// Inactivity window before the model is unloaded in lazy mode. Defaults to 1 minute.
+    static var modelIdleTimeout: ModelIdleTimeout {
+        get {
+            guard let raw = defaults.string(forKey: modelIdleTimeoutKey),
+                  let value = ModelIdleTimeout(rawValue: raw) else {
+                return .oneMinute
+            }
+            return value
+        }
+        set { defaults.set(newValue.rawValue, forKey: modelIdleTimeoutKey) }
+    }
 
     static var recordingShortcut: RecordingShortcut {
         get {

--- a/LemonWhisper/LemonWhisper/Services/ModelMemoryController.swift
+++ b/LemonWhisper/LemonWhisper/Services/ModelMemoryController.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Backend-agnostic control over whether a transcription model is resident in memory.
+///
+/// Both transcription backends already load lazily at transcription time; this protocol
+/// lets the app proactively warm up (fast mode / parallel-with-recording) or free memory
+/// (lazy idle timeout) without the caller needing to know which backend is active.
+protocol ModelMemoryController: Sendable {
+    func isLoaded() async -> Bool
+    /// Load the model. If `weightMaterializationBudget` is non-nil, also make weights fully
+    /// resident now — but only if the backend expects that to complete within the budget (e.g.
+    /// shorter than a typical recording). Pass `.infinity` to always do it (fast mode), `nil` to
+    /// skip it. Backends that allocate weights eagerly on load ignore the budget.
+    func warmUp(weightMaterializationBudget: TimeInterval?) async throws
+    func unload() async
+}
+
+/// whisper.cpp adapter. The C context is allocated eagerly by `whisper_init_*`, so warming up
+/// materializes memory immediately (no separate evaluation step needed).
+struct WhisperMemoryController: ModelMemoryController {
+    func isLoaded() async -> Bool {
+        WhisperContext.getShared() != nil
+    }
+
+    func warmUp(weightMaterializationBudget: TimeInterval?) async throws {
+        // whisper.cpp allocates the model on init, so weights are always resident after load;
+        // the budget is a no-op here.
+        guard WhisperContext.getShared() == nil else { return }
+        guard let selected = WhisperModelCatalog.selectedModelIfDownloaded() else {
+            throw WhisperStateError.modelLoadFailed
+        }
+        _ = try await WhisperContext.createContext(path: selected.localURL.path)
+        try await WhisperModelCatalog.ensureVADDownloadedIfNeeded()
+        if let context = WhisperContext.getShared() {
+            await context.setVADModelPath(WhisperModelCatalog.vadLocalURL.path)
+        }
+    }
+
+    func unload() async {
+        await WhisperContext.getShared()?.releaseResources()
+        WhisperContext.clearShared()
+    }
+}
+
+/// Voxtral/MLX adapter. Delegates to the service, which forces weight materialization during warmup.
+struct VoxtralMemoryController: ModelMemoryController {
+    func isLoaded() async -> Bool {
+        await VoxtralService.shared.isReady
+    }
+
+    func warmUp(weightMaterializationBudget: TimeInterval?) async throws {
+        try await VoxtralService.shared.warmupModel(weightMaterializationBudget: weightMaterializationBudget)
+    }
+
+    func unload() async {
+        await VoxtralService.shared.unload()
+    }
+}

--- a/LemonWhisper/LemonWhisper/Services/TranscriptionHistoryStore.swift
+++ b/LemonWhisper/LemonWhisper/Services/TranscriptionHistoryStore.swift
@@ -12,6 +12,8 @@ struct TranscriptionRecord: Identifiable, Hashable {
     let backend: String
     let language: String
     let targetBundleIdentifier: String?
+    let recordingStartedAt: Date?
+    let recordingStoppedAt: Date?
     let pasteStatus: String
     let pastePath: String?
     let pasteError: String?
@@ -99,7 +101,9 @@ actor TranscriptionHistoryDatabase {
         correctedText: String? = nil,
         language: String,
         backend: String,
-        targetBundleIdentifier: String?
+        targetBundleIdentifier: String?,
+        recordingStartedAt: Date? = nil,
+        recordingStoppedAt: Date? = nil
     ) throws -> TranscriptionRecord {
         let record = TranscriptionRecord(
             id: UUID(),
@@ -109,6 +113,8 @@ actor TranscriptionHistoryDatabase {
             backend: backend,
             language: language,
             targetBundleIdentifier: targetBundleIdentifier,
+            recordingStartedAt: recordingStartedAt,
+            recordingStoppedAt: recordingStoppedAt,
             pasteStatus: "pending",
             pastePath: nil,
             pasteError: nil,
@@ -124,11 +130,13 @@ actor TranscriptionHistoryDatabase {
             backend,
             language,
             target_bundle_identifier,
+            recording_started_at,
+            recording_stopped_at,
             paste_status,
             paste_path,
             paste_error,
             paste_completed_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
         """
 
         let statement = try prepareStatement(sql)
@@ -141,10 +149,12 @@ actor TranscriptionHistoryDatabase {
         try bindText(record.backend, at: 5, in: statement)
         try bindText(record.language, at: 6, in: statement)
         try bindOptionalText(record.targetBundleIdentifier, at: 7, in: statement)
-        try bindText(record.pasteStatus, at: 8, in: statement)
-        try bindOptionalText(record.pastePath, at: 9, in: statement)
-        try bindOptionalText(record.pasteError, at: 10, in: statement)
-        sqlite3_bind_null(statement, 11)
+        bindOptionalDate(record.recordingStartedAt, at: 8, in: statement)
+        bindOptionalDate(record.recordingStoppedAt, at: 9, in: statement)
+        try bindText(record.pasteStatus, at: 10, in: statement)
+        try bindOptionalText(record.pastePath, at: 11, in: statement)
+        try bindOptionalText(record.pasteError, at: 12, in: statement)
+        sqlite3_bind_null(statement, 13)
 
         guard sqlite3_step(statement) == SQLITE_DONE else {
             throw TranscriptionHistoryError.statementExecutionFailed(lastErrorMessage())
@@ -163,6 +173,8 @@ actor TranscriptionHistoryDatabase {
             backend,
             language,
             target_bundle_identifier,
+            recording_started_at,
+            recording_stopped_at,
             paste_status,
             paste_path,
             paste_error,
@@ -191,6 +203,8 @@ actor TranscriptionHistoryDatabase {
             backend,
             language,
             target_bundle_identifier,
+            recording_started_at,
+            recording_stopped_at,
             paste_status,
             paste_path,
             paste_error,
@@ -220,12 +234,12 @@ actor TranscriptionHistoryDatabase {
             let correctedText = stringColumn(at: 2, in: statement)
             let createdAt = Date(timeIntervalSince1970: sqlite3_column_double(statement, 3))
             let targetBundleIdentifier = stringColumn(at: 6, in: statement)
-            let pasteStatus = stringColumn(at: 7, in: statement) ?? "unknown"
-            let pastePath = stringColumn(at: 8, in: statement)
-            let pasteError = stringColumn(at: 9, in: statement)
-            let pasteCompletedAt = sqlite3_column_type(statement, 10) == SQLITE_NULL
-                ? nil
-                : Date(timeIntervalSince1970: sqlite3_column_double(statement, 10))
+            let recordingStartedAt = dateColumn(at: 7, in: statement)
+            let recordingStoppedAt = dateColumn(at: 8, in: statement)
+            let pasteStatus = stringColumn(at: 9, in: statement) ?? "unknown"
+            let pastePath = stringColumn(at: 10, in: statement)
+            let pasteError = stringColumn(at: 11, in: statement)
+            let pasteCompletedAt = dateColumn(at: 12, in: statement)
 
             records.append(
                 TranscriptionRecord(
@@ -236,6 +250,8 @@ actor TranscriptionHistoryDatabase {
                     backend: backend,
                     language: language,
                     targetBundleIdentifier: targetBundleIdentifier,
+                    recordingStartedAt: recordingStartedAt,
+                    recordingStoppedAt: recordingStoppedAt,
                     pasteStatus: pasteStatus,
                     pastePath: pastePath,
                     pasteError: pasteError,
@@ -335,12 +351,27 @@ actor TranscriptionHistoryDatabase {
             backend TEXT NOT NULL,
             language TEXT NOT NULL,
             target_bundle_identifier TEXT,
+            recording_started_at REAL,
+            recording_stopped_at REAL,
             paste_status TEXT NOT NULL DEFAULT 'unknown',
             paste_path TEXT,
             paste_error TEXT,
             paste_completed_at REAL
         );
         """,
+            on: connection
+        )
+
+        try addColumnIfNeeded(
+            named: "recording_started_at",
+            definition: "REAL",
+            to: "transcriptions",
+            on: connection
+        )
+        try addColumnIfNeeded(
+            named: "recording_stopped_at",
+            definition: "REAL",
+            to: "transcriptions",
             on: connection
         )
 
@@ -470,11 +501,26 @@ actor TranscriptionHistoryDatabase {
         try bindText(value, at: index, in: statement)
     }
 
+    private func bindOptionalDate(_ value: Date?, at index: Int32, in statement: OpaquePointer?) {
+        guard let value else {
+            sqlite3_bind_null(statement, index)
+            return
+        }
+        sqlite3_bind_double(statement, index, value.timeIntervalSince1970)
+    }
+
     private func stringColumn(at index: Int32, in statement: OpaquePointer?) -> String? {
         guard let pointer = sqlite3_column_text(statement, index) else {
             return nil
         }
         return String(cString: pointer)
+    }
+
+    private func dateColumn(at index: Int32, in statement: OpaquePointer?) -> Date? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL else {
+            return nil
+        }
+        return Date(timeIntervalSince1970: sqlite3_column_double(statement, index))
     }
 
     private static func lastErrorMessage(on connection: OpaquePointer?) -> String {
@@ -558,7 +604,9 @@ final class TranscriptionHistoryStore: ObservableObject {
         rawText: String,
         language: String,
         backend: TranscriptionBackend,
-        targetBundleIdentifier: String?
+        targetBundleIdentifier: String?,
+        recordingStartedAt: Date? = nil,
+        recordingStoppedAt: Date? = nil
     ) async -> TranscriptionRecord? {
         let sanitized = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !sanitized.isEmpty else { return nil }
@@ -568,7 +616,9 @@ final class TranscriptionHistoryStore: ObservableObject {
                 rawText: sanitized,
                 language: language,
                 backend: backend.rawValue,
-                targetBundleIdentifier: targetBundleIdentifier
+                targetBundleIdentifier: targetBundleIdentifier,
+                recordingStartedAt: recordingStartedAt,
+                recordingStoppedAt: recordingStoppedAt
             )
             items.insert(record, at: 0)
             lastError = nil
@@ -605,6 +655,8 @@ final class TranscriptionHistoryStore: ObservableObject {
                     backend: existing.backend,
                     language: existing.language,
                     targetBundleIdentifier: existing.targetBundleIdentifier,
+                    recordingStartedAt: existing.recordingStartedAt,
+                    recordingStoppedAt: existing.recordingStoppedAt,
                     pasteStatus: pasteStatus,
                     pastePath: pastePath,
                     pasteError: pasteError,
@@ -669,6 +721,8 @@ final class TranscriptionHistoryStore: ObservableObject {
             "backend",
             "language",
             "target_bundle_identifier",
+            "recording_started_at",
+            "recording_stopped_at",
             "paste_status",
             "paste_path",
             "paste_error",
@@ -685,6 +739,8 @@ final class TranscriptionHistoryStore: ObservableObject {
                 record.backend,
                 record.language,
                 record.targetBundleIdentifier ?? "",
+                record.recordingStartedAt.map { Self.exportDateFormatter.string(from: $0) } ?? "",
+                record.recordingStoppedAt.map { Self.exportDateFormatter.string(from: $0) } ?? "",
                 record.pasteStatus,
                 record.pastePath ?? "",
                 record.pasteError ?? "",

--- a/LemonWhisper/LemonWhisper/Services/VoxtralService.swift
+++ b/LemonWhisper/LemonWhisper/Services/VoxtralService.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 #if canImport(VoxtralCore)
@@ -44,6 +45,11 @@ actor VoxtralService {
     private var loadedModelID: String?
     private var isLoadingModel = false
     private var lastErrorMessage: String?
+    private var didMaterializeWeights = false
+    /// Measured wall-clock cost of one weight-materialization pass. Kept across unloads because
+    /// it is a property of the model, not of any single load. Used to decide whether eager
+    /// materialization can finish within a caller-supplied time budget.
+    private var lastMaterializationDuration: TimeInterval?
 
     private var selectedModelID: String
 
@@ -187,9 +193,18 @@ actor VoxtralService {
 #endif
     }
 
-    func warmupModel() async throws {
+    /// Loads the pipeline. With a non-nil `weightMaterializationBudget`, also runs a one-time
+    /// throwaway inference so weights are resident immediately — but only if a prior measurement
+    /// shows that pass fits within the budget (pass `.infinity` to always do it, as in fast mode).
+    /// A `nil` budget loads the graph only and leaves materialization to the first transcription.
+    func warmupModel(weightMaterializationBudget: TimeInterval? = nil) async throws {
 #if canImport(VoxtralCore)
-        _ = try await loadPipelineIfNeeded()
+        let pipeline = try await loadPipelineIfNeeded()
+        guard let budget = weightMaterializationBudget else { return }
+        // If we've already measured materialization as slower than the budget (e.g. longer than a
+        // typical recording), skip it here so it can't block the real transcription.
+        if let measured = lastMaterializationDuration, measured >= budget { return }
+        await materializeWeightsIfNeeded(pipeline)
 #else
         throw VoxtralServiceError.unavailable
 #endif
@@ -201,6 +216,7 @@ actor VoxtralService {
         pipeline = nil
         loadedModelID = nil
         lastErrorMessage = nil
+        didMaterializeWeights = false
 #endif
     }
 
@@ -247,6 +263,45 @@ actor VoxtralService {
         default:
             return nil
         }
+    }
+
+    /// MLX evaluates lazily: `loadModel` builds the graph, but the weight arrays are not
+    /// materialized in memory until the first forward pass. That is why memory only spikes on
+    /// the first real transcription. Run one throwaway inference on silence so that cost (and
+    /// the associated latency) is paid at warmup instead. Best-effort — never fails warmup.
+    private func materializeWeightsIfNeeded(_ pipeline: VoxtralPipeline) async {
+        guard !didMaterializeWeights else { return }
+        guard let silenceURL = try? Self.makeSilentClip() else { return }
+        defer { try? FileManager.default.removeItem(at: silenceURL) }
+        let start = Date()
+        _ = try? await pipeline.transcribe(audio: silenceURL, language: "en")
+        let elapsed = Date().timeIntervalSince(start)
+        lastMaterializationDuration = elapsed
+        didMaterializeWeights = true
+        print("🧠 Voxtral weights materialized in \(Int(elapsed * 1000)) ms")
+    }
+
+    private static func makeSilentClip() throws -> URL {
+        let sampleRate = 16_000.0
+        let frames = AVAudioFrameCount(sampleRate * 0.3)
+        guard
+            let format = AVAudioFormat(
+                commonFormat: .pcmFormatFloat32,
+                sampleRate: sampleRate,
+                channels: 1,
+                interleaved: false
+            ),
+            let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: frames)
+        else {
+            throw VoxtralServiceError.loadFailed("Could not allocate warmup buffer")
+        }
+
+        buffer.frameLength = frames // Freshly allocated buffers are zero-filled == silence.
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voxtral-warmup-\(UUID().uuidString).wav")
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        try file.write(from: buffer)
+        return url
     }
 
     private func removeIncompleteModelIfPresent(_ info: VoxtralModelInfo) {

--- a/LemonWhisper/LemonWhisper/Views/ContentView.swift
+++ b/LemonWhisper/LemonWhisper/Views/ContentView.swift
@@ -116,6 +116,20 @@ struct ContentView: View {
         )
     }
 
+    private var modelLoadingModeBinding: Binding<ModelLoadingMode> {
+        Binding(
+            get: { controller.modelLoadingMode },
+            set: { controller.setModelLoadingMode($0) }
+        )
+    }
+
+    private var modelIdleTimeoutBinding: Binding<ModelIdleTimeout> {
+        Binding(
+            get: { controller.modelIdleTimeout },
+            set: { controller.setModelIdleTimeout($0) }
+        )
+    }
+
     private func applyModelSelection(key: String) {
         guard let model = downloadedModels.first(where: { $0.id == key }) else { return }
         switch model.engine {
@@ -219,6 +233,33 @@ struct ContentView: View {
 
                 HomeValueRow(title: "Shortcut") {
                     ShortcutRecorderControl(shortcut: shortcutBinding)
+                }
+
+                Divider()
+
+                HomeValueRow(
+                    title: "Model loading",
+                    bottomPadding: controller.modelLoadingMode == .lazy ? 4 : 14
+                ) {
+                    Picker("", selection: modelLoadingModeBinding) {
+                        ForEach(ModelLoadingMode.allCases) { mode in
+                            Text(mode.menuTitle).tag(mode)
+                        }
+                    }
+                    .labelsHidden()
+                    .frame(width: 220, alignment: .trailing)
+                }
+
+                if controller.modelLoadingMode == .lazy {
+                    HomeValueRow(title: "Idle timeout", topPadding: 4) {
+                        Picker("", selection: modelIdleTimeoutBinding) {
+                            ForEach(ModelIdleTimeout.allCases) { option in
+                                Text(option.title).tag(option)
+                            }
+                        }
+                        .labelsHidden()
+                        .frame(width: 220, alignment: .trailing)
+                    }
                 }
 
                 Divider()
@@ -434,10 +475,19 @@ private struct SetupStatusCard: View {
 
 private struct HomeValueRow<Accessory: View>: View {
     let title: String
+    var topPadding: CGFloat = 14
+    var bottomPadding: CGFloat = 14
     let accessory: Accessory
 
-    init(title: String, @ViewBuilder accessory: () -> Accessory) {
+    init(
+        title: String,
+        topPadding: CGFloat = 14,
+        bottomPadding: CGFloat = 14,
+        @ViewBuilder accessory: () -> Accessory
+    ) {
         self.title = title
+        self.topPadding = topPadding
+        self.bottomPadding = bottomPadding
         self.accessory = accessory()
     }
 
@@ -451,6 +501,7 @@ private struct HomeValueRow<Accessory: View>: View {
             accessory
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        .padding(.top, topPadding)
+        .padding(.bottom, bottomPadding)
     }
 }

--- a/LemonWhisper/LemonWhisper/Views/MenuBarContentView.swift
+++ b/LemonWhisper/LemonWhisper/Views/MenuBarContentView.swift
@@ -98,6 +98,20 @@ struct MenuBarContentView: View {
             }
         }
 
+        Menu("Model Loading") {
+            ForEach(ModelLoadingMode.allCases) { mode in
+                Button {
+                    controller.setModelLoadingMode(mode)
+                } label: {
+                    if controller.modelLoadingMode == mode {
+                        Text("✓ \(mode.title)")
+                    } else {
+                        Text(mode.title)
+                    }
+                }
+            }
+        }
+
         Menu("Transcriptions") {
             Button("Open History") {
                 navigationState.show(.transcriptions)

--- a/LemonWhisper/LemonWhisperTests/AppSettingsStoreTests.swift
+++ b/LemonWhisper/LemonWhisperTests/AppSettingsStoreTests.swift
@@ -49,6 +49,26 @@ struct AppSettingsStoreTests {
         }
     }
 
+    @Test func modelLoadingModeDefaultsToFastAndRoundTrips() {
+        withTemporaryDefaults {
+            #expect(AppSettingsStore.modelLoadingMode == .fast)
+
+            AppSettingsStore.modelLoadingMode = .lazy
+            #expect(AppSettingsStore.modelLoadingMode == .lazy)
+        }
+    }
+
+    @Test func modelIdleTimeoutDefaultsToOneMinuteAndRoundTrips() {
+        withTemporaryDefaults {
+            #expect(AppSettingsStore.modelIdleTimeout == .oneMinute)
+            #expect(AppSettingsStore.modelIdleTimeout.seconds == 60)
+
+            AppSettingsStore.modelIdleTimeout = .fiveMinutes
+            #expect(AppSettingsStore.modelIdleTimeout == .fiveMinutes)
+            #expect(AppSettingsStore.modelIdleTimeout.seconds == 300)
+        }
+    }
+
     private func withTemporaryDefaults(_ body: () -> Void) {
         let suiteName = "LemonWhisperTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/LemonWhisper/LemonWhisperTests/TranscriptionHistoryDatabaseTests.swift
+++ b/LemonWhisper/LemonWhisperTests/TranscriptionHistoryDatabaseTests.swift
@@ -66,6 +66,50 @@ struct TranscriptionHistoryDatabaseTests {
         #expect(records.isEmpty)
     }
 
+    @Test func persistsRecordingTimestamps() async throws {
+        let fileManager = FileManager.default
+        let tempDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: tempDirectory)
+        }
+
+        let database = try TranscriptionHistoryDatabase(
+            databaseURL: tempDirectory.appendingPathComponent("Transcriptions.sqlite")
+        )
+
+        let startedAt = Date(timeIntervalSince1970: 1000)
+        let stoppedAt = Date(timeIntervalSince1970: 1005)
+
+        _ = try await database.insert(
+            rawText: "timed transcription",
+            language: "en",
+            backend: "whisper",
+            targetBundleIdentifier: nil,
+            recordingStartedAt: startedAt,
+            recordingStoppedAt: stoppedAt
+        )
+
+        let records = try await database.fetchLatest(limit: 10)
+        #expect(records.count == 1)
+        #expect(records[0].recordingStartedAt == startedAt)
+        #expect(records[0].recordingStoppedAt == stoppedAt)
+
+        // Paste metadata updates must preserve the recording timestamps.
+        try await database.updatePasteMetadata(
+            id: records[0].id,
+            pasteStatus: "succeeded",
+            pastePath: "commandV",
+            pasteError: nil,
+            pasteCompletedAt: Date(timeIntervalSince1970: 1010)
+        )
+
+        let updated = try await database.fetchLatest(limit: 10)
+        #expect(updated[0].recordingStartedAt == startedAt)
+        #expect(updated[0].recordingStoppedAt == stoppedAt)
+        #expect(updated[0].pasteCompletedAt == Date(timeIntervalSince1970: 1010))
+    }
+
     @Test func updatesPasteMetadata() async throws {
         let fileManager = FileManager.default
         let tempDirectory = fileManager.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
Addresses #13 (decrease memory consumption) and adds latency-analysis timestamps.

## Memory modes (#13)
- **Fast** (default) — model loads at startup and stays resident; every transcription is instant. For Voxtral, warmup now forces MLX to materialize weights up front (previously memory only spiked on the first transcription because MLX evaluates lazily).
- **Lazy** — no startup load; the model loads on demand and unloads after a configurable idle timeout (30s / 1m / 2m / 5m). The pipeline loads *in parallel with recording* so the wait is hidden. Weight materialization is gated by a measured time budget, so it only runs eagerly when it can finish within a typical recording — never blocking a transcription.

## Recording never blocks on model load
Recording now starts optimistically whenever a usable model exists on disk, regardless of whether it's loaded in memory. A hotkey press is only refused when there's genuinely no model downloaded. This fixes the bug where a hotkey during model load was silently dropped.

## Model-agnostic design
A small `ModelMemoryController` protocol (Whisper + Voxtral adapters) means warmup / unload / idle logic is written once and applies to any backend.

## UX
- Fast/Lazy toggle in the menu bar and settings window.
- Idle-timeout presets in settings (shown only in Lazy mode).
- Process-memory readout refreshes immediately after any load/unload so the user sees memory freed or tied up.

## Transcription history timestamps
Each transcription now records **recording-start** and **recording-stop** times alongside the existing **paste-completed** time (schema migration + CSV export), enabling speed analysis of record duration and transcription+paste latency.

## Tests
Added coverage for the new settings and the recording timestamps; full unit suite passes and the app builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)