### PR TITLE
Add option-hold quick pick for recent transcriptions

### DIFF
--- a/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+System.swift
+++ b/LemonWhisper/LemonWhisper/Controllers/LemonWhisperController+System.swift
@@ -43,5 +43,16 @@ extension LemonWhisperController {
                 self.cancelRecording()
             }
         }
+
+        NotificationCenter.default.addObserver(
+            forName: .optionHoldHotKey,
+            object: nil,
+            queue: .main
+        ) { _ in
+            debugLog("🔔 Option long-press notification received on main queue")
+            Task { @MainActor in
+                QuickPickHUD.shared.show()
+            }
+        }
     }
 }

--- a/LemonWhisper/LemonWhisper/Managers/HotKeyManager.swift
+++ b/LemonWhisper/LemonWhisper/Managers/HotKeyManager.swift
@@ -5,6 +5,7 @@ import AppKit
 extension Notification.Name {
     static let toggleRecordingHotKey = Notification.Name("toggleRecordingHotKey")
     static let cancelRecordingHotKey = Notification.Name("cancelRecordingHotKey")
+    static let optionHoldHotKey = Notification.Name("optionHoldHotKey")
 }
 
 private func hotKeyHandler(
@@ -22,8 +23,13 @@ private func hotKeyHandler(
 enum HotKeyManager {
     private static var globalFlagsMonitor: Any?
     private static var localFlagsMonitor: Any?
+    private static var globalKeyDownMonitor: Any?
+    private static var localKeyDownMonitor: Any?
     private static var lastControlTapDate: Date?
     private static let doubleTapThreshold: TimeInterval = 0.35
+    private static var optionHoldWorkItem: DispatchWorkItem?
+    private static let optionHoldDuration: TimeInterval = 2.0
+    private static let modifierRelevantMask: NSEvent.ModifierFlags = [.command, .control, .option, .shift, .function]
     private static var handlerInstalled = false
 
     static func registerToggleRecordingHotKey(into hotKeyRef: inout EventHotKeyRef?, keyCode: UInt32, modifiers: UInt32) {
@@ -90,9 +96,23 @@ enum HotKeyManager {
             handleFlagsChanged(event)
             return event
         }
+
+        globalKeyDownMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { _ in
+            cancelPendingOptionHold()
+        }
+
+        localKeyDownMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            cancelPendingOptionHold()
+            return event
+        }
     }
 
     private static func handleFlagsChanged(_ event: NSEvent) {
+        handleControlDoubleTap(event)
+        handleOptionHold(event)
+    }
+
+    private static func handleControlDoubleTap(_ event: NSEvent) {
         guard event.keyCode == 59 || event.keyCode == 62 else { return }
 
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
@@ -109,5 +129,29 @@ enum HotKeyManager {
         }
 
         lastControlTapDate = now
+    }
+
+    /// Fires `.optionHoldHotKey` if Option is held alone (no other modifier) for `optionHoldDuration`.
+    /// Any other key press, or releasing Option early, cancels the pending timer.
+    private static func handleOptionHold(_ event: NSEvent) {
+        guard event.keyCode == kVK_Option || event.keyCode == kVK_RightOption else { return }
+
+        let flags = event.modifierFlags.intersection(modifierRelevantMask)
+        guard flags == .option else {
+            cancelPendingOptionHold()
+            return
+        }
+
+        let workItem = DispatchWorkItem {
+            debugLog("⌨️ Option long-press detected")
+            NotificationCenter.default.post(name: .optionHoldHotKey, object: nil)
+        }
+        optionHoldWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + optionHoldDuration, execute: workItem)
+    }
+
+    private static func cancelPendingOptionHold() {
+        optionHoldWorkItem?.cancel()
+        optionHoldWorkItem = nil
     }
 }

--- a/LemonWhisper/LemonWhisper/UI/HUD/QuickPickHUD.swift
+++ b/LemonWhisper/LemonWhisper/UI/HUD/QuickPickHUD.swift
@@ -1,0 +1,184 @@
+import AppKit
+import SwiftUI
+
+/// Glassy popup listing the most recent transcriptions, shown near the cursor when
+/// Option is held for 2s. Clicking a row copies it to the clipboard and dismisses;
+/// clicking anywhere else dismisses without copying.
+@MainActor
+final class QuickPickHUD {
+    static let shared = QuickPickHUD()
+
+    private var panel: NSPanel?
+    private var globalClickMonitor: Any?
+    private var localClickMonitor: Any?
+
+    private let rowHeight: CGFloat = 40
+    private let width: CGFloat = 320
+    private let maxRows = 10
+    private let cornerRadius: CGFloat = 14
+
+    private init() {}
+
+    func show() {
+        let records = Array(TranscriptionHistoryStore.shared.items.prefix(maxRows))
+        guard !records.isEmpty else { return }
+
+        hide(animated: false)
+
+        let size = CGSize(width: width, height: rowHeight * CGFloat(records.count))
+        let panel = makePanel(size: size)
+        panel.contentView = makeContentView(records: records, size: size)
+        position(panel, size: size)
+
+        self.panel = panel
+        panel.alphaValue = 0
+        panel.orderFrontRegardless()
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0.12
+            panel.animator().alphaValue = 1
+        }
+
+        installClickAwayMonitorsIfNeeded()
+    }
+
+    func hide(animated: Bool = true) {
+        removeClickAwayMonitors()
+        guard let panel else { return }
+        self.panel = nil
+
+        guard animated else {
+            panel.orderOut(nil)
+            return
+        }
+
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.12
+            panel.animator().alphaValue = 0
+        }, completionHandler: {
+            panel.orderOut(nil)
+        })
+    }
+
+    private func makePanel(size: CGSize) -> NSPanel {
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: size),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.ignoresMouseEvents = false
+        panel.hidesOnDeactivate = false
+        panel.level = .floating
+        panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+        return panel
+    }
+
+    private func makeContentView(records: [TranscriptionRecord], size: CGSize) -> NSView {
+        let container = NSVisualEffectView(frame: NSRect(origin: .zero, size: size))
+        container.material = .hudWindow
+        container.blendingMode = .behindWindow
+        container.state = .active
+        container.wantsLayer = true
+        container.layer?.cornerRadius = cornerRadius
+        container.layer?.masksToBounds = true
+
+        let rootView = QuickPickListView(records: records, rowHeight: rowHeight) { [weak self] record in
+            TranscriptionHistoryStore.shared.copyToClipboard(record)
+            self?.hide()
+        }
+        let hostingView = NSHostingView(rootView: rootView)
+        hostingView.frame = NSRect(origin: .zero, size: size)
+        hostingView.autoresizingMask = [.width, .height]
+        container.addSubview(hostingView)
+
+        return container
+    }
+
+    private func position(_ panel: NSPanel, size: CGSize) {
+        let mouseLocation = NSEvent.mouseLocation
+        var origin = NSPoint(x: mouseLocation.x + 12, y: mouseLocation.y - size.height - 12)
+
+        let screen = NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main
+        if let visibleFrame = screen?.visibleFrame {
+            origin.x = min(max(origin.x, visibleFrame.minX), visibleFrame.maxX - size.width)
+            origin.y = min(max(origin.y, visibleFrame.minY), visibleFrame.maxY - size.height)
+        }
+
+        panel.setFrameOrigin(origin)
+    }
+
+    private func installClickAwayMonitorsIfNeeded() {
+        guard globalClickMonitor == nil, localClickMonitor == nil else { return }
+
+        globalClickMonitor = NSEvent.addGlobalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.hide()
+            }
+        }
+
+        localClickMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .rightMouseDown]) { [weak self] event in
+            guard let self, let panel = self.panel, event.window !== panel else { return event }
+            self.hide()
+            return event
+        }
+    }
+
+    private func removeClickAwayMonitors() {
+        if let globalClickMonitor { NSEvent.removeMonitor(globalClickMonitor) }
+        if let localClickMonitor { NSEvent.removeMonitor(localClickMonitor) }
+        globalClickMonitor = nil
+        localClickMonitor = nil
+    }
+}
+
+private struct QuickPickListView: View {
+    let records: [TranscriptionRecord]
+    let rowHeight: CGFloat
+    let onSelect: (TranscriptionRecord) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(records.enumerated()), id: \.element.id) { index, record in
+                QuickPickRow(record: record, onSelect: { onSelect(record) })
+                    .frame(height: rowHeight)
+
+                if index < records.count - 1 {
+                    Divider()
+                        .padding(.horizontal, 12)
+                }
+            }
+        }
+    }
+}
+
+private struct QuickPickRow: View {
+    let record: TranscriptionRecord
+    let onSelect: () -> Void
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: onSelect) {
+            HStack(spacing: 10) {
+                Text(record.excerpt(maxLength: 46))
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                Text(record.timestampLabel)
+                    .font(.system(size: 10.5))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(isHovering ? Color.primary.opacity(0.08) : Color.clear)
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovering = $0 }
+    }
+}


### PR DESCRIPTION
## Summary
- Holding Option alone for 2s posts a new `.optionHoldHotKey` notification (any other key press, releasing early, or combining with another modifier cancels the pending timer).
- New `QuickPickHUD` shows a glassy, cursor-anchored `NSPanel` (reusing the HUD glass styling from `HUDPanels.swift`) listing the last 10 items from `TranscriptionHistoryStore.shared.items`.
- Clicking a row calls the existing `TranscriptionHistoryStore.copyToClipboard(_:)` and dismisses; clicking anywhere else dismisses without copying (global + local click monitors).

## Test plan
- [x] `xcodebuild build` succeeds
- [ ] Manually verify: hold Option 2s near cursor shows popup with recent transcriptions
- [ ] Manually verify: clicking a row copies its text and closes the popup
- [ ] Manually verify: clicking elsewhere (in-app or another app) closes without copying
- [ ] Manually verify: pressing another key while holding Option does not trigger the popup
- [ ] Manually verify: existing double-tap-Control cancel-recording behavior still works